### PR TITLE
Fix bug in find_tiles in the python V3 code

### DIFF
--- a/python/pmtiles/tile.py
+++ b/python/pmtiles/tile.py
@@ -85,7 +85,7 @@ def tileid_to_zxy(tile_id):
 def find_tile(entries, tile_id):
     m = 0
     n = len(entries) - 1
-    while m < n:
+    while m <= n:
         k = (n + m) >> 1
         c = tile_id - entries[k].tile_id
         if c > 0:

--- a/python/pmtiles/v2.py
+++ b/python/pmtiles/v2.py
@@ -1,3 +1,4 @@
+import json
 from collections import namedtuple
 
 


### PR DESCRIPTION
The good news is this stuff is pretty obviously broken when it's broken.  I noticed that the JS example was working with my file but the python version was not, so I traced the differences until I found the problem.  Let me know if this looks right.